### PR TITLE
Remove time spent in seconds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dmypy.json
 
 # VS Code
 .vscode
+.idea

--- a/surge/responses.py
+++ b/surge/responses.py
@@ -20,11 +20,9 @@ class Response(object):
 
 
 class TaskResponse(Response):
-    def __init__(self, id: str, data: dict, time_spent_in_secs: int,
-                 completed_at: datetime, worker_id: str):
+    def __init__(self, id: str, data: dict, completed_at: datetime, worker_id: str):
         super().__init__(id)
         self.data = data
-        self.time_spent_in_secs = time_spent_in_secs
         self.completed_at = completed_at
         self.worker_id = worker_id
 

--- a/surge/tasks.py
+++ b/surge/tasks.py
@@ -21,7 +21,7 @@ class Task(APIResource):
         # If Task has responses, convert each into a TaskResponse object
         if hasattr(self, "responses"):
             task_responses = [
-                TaskResponse(r["id"], r["data"], r["time_spent_in_secs"],
+                TaskResponse(r["id"], r["data"],
                              dateutil.parser.parse(r["completed_at"]),
                              r["worker_id"]) for r in self.responses
             ]

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -68,7 +68,6 @@ def test_init_complete():
             'data': {
                 'What is the result of this pitch?': 'Foul Tip'
             },
-            'time_spent_in_secs': 22,
             'completed_at': '2021-01-22T20:57:13.273Z',
             'worker_id': 'J14X3BTCZX3M'
         }]


### PR DESCRIPTION
- Remove `time_spent_in_secs` from TaskResponse object in API
- Fixes https://github.com/surge-ai/gondor/issues/2711