### PR TITLE
Add use_for_serial_collection to free response question

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '1.0.26'
+VERSION = '1.0.27'
 
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()

--- a/surge/questions.py
+++ b/surge/questions.py
@@ -15,9 +15,10 @@ class Question(object):
 
 
 class FreeResponseQuestion(Question):
-    def __init__(self, text, required=True, preexisting_annotations=None):
+    def __init__(self, text, required=True, preexisting_annotations=None, use_for_serial_collection=False):
         super().__init__(text, type_="free_response", required=required)
         self.preexisting_annotations = preexisting_annotations
+        self.use_for_serial_collection = use_for_serial_collection
 
 
 class MultipleChoiceQuestion(Question):

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -314,6 +314,7 @@ def test_convert_questions_to_objects():
     assert type(questions[2]) == FreeResponseQuestion
     assert questions[2].text == 'Free response for {{url}}'
     assert questions[2].required == False
+    assert questions[2].use_for_serial_collection == False
     assert not hasattr(questions[2], "options")
 
     assert type(questions[3]) == TextTaggingQuestion


### PR DESCRIPTION
For context: https://surge-ai.slack.com/archives/C039K6QBNNT/p1669219089715839?thread_ts=1669121855.981299&cid=C039K6QBNNT

I think this is all that's necessary, but I'm not sure how to really test.