### PR TITLE
Add new fields to question, as well as update capabilities

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '1.0.32'
+VERSION = '1.0.33'
 
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()

--- a/surge/api_resource.py
+++ b/surge/api_resource.py
@@ -8,6 +8,7 @@ BASE_URL = "https://app.surgehq.ai/api"
 PROJECTS_ENDPOINT = "projects"
 TASKS_ENDPOINT = "tasks"
 REPORTS_ENDPOINT = "projects"
+QUESTIONS_ENDPOINT = "items"
 
 
 class APIResource(object):

--- a/surge/api_resource.py
+++ b/surge/api_resource.py
@@ -12,6 +12,7 @@ QUESTIONS_ENDPOINT = "items"
 
 
 class APIResource(object):
+
     def __init__(self, id=None):
         self.id = id
 

--- a/surge/carousel.py
+++ b/surge/carousel.py
@@ -2,6 +2,7 @@ import json
 
 
 class Carousel(object):
+
     def __init__(self, carousel_type=None):
         self.carousel_type = carousel_type
 
@@ -11,13 +12,17 @@ class Carousel(object):
     def to_json(self):
         return json.dumps(self.to_dict())
 
+
 class BoundedRoundsCarousel(Carousel):
+
     def __init__(self, min_rounds_for_carousel=1, max_rounds_for_carousel=1):
         super().__init__(carousel_type="bounded_rounds")
         self.min_rounds_for_carousel = min_rounds_for_carousel
         self.max_rounds_for_carousel = max_rounds_for_carousel
 
+
 class DataKeyCarousel(Carousel):
+
     def __init__(self, carousel_data_key=None):
         super().__init__(carousel_type="data_key")
         self.carousel_data_key = carousel_data_key

--- a/surge/errors.py
+++ b/surge/errors.py
@@ -1,5 +1,6 @@
 class SurgeRequestError(Exception):
     """Catch-all exception for errors that occur when making a request"""
+
     def __init__(self, message="Something went wrong with the API request."):
         self.message = message
         super().__init__(self.message)
@@ -7,6 +8,7 @@ class SurgeRequestError(Exception):
 
 class SurgeMissingAPIKeyError(Exception):
     """Raise when user has not set their API key"""
+
     def __init__(self, message="Surge API key has not been set."):
         self.message = message
         super().__init__(self.message)
@@ -14,6 +16,7 @@ class SurgeMissingAPIKeyError(Exception):
 
 class SurgeMissingIDError(Exception):
     """Raise when a Surge object is missing an ID"""
+
     def __init__(self, message="Must be initialized with an id."):
         self.message = message
         super().__init__(self.message)
@@ -21,6 +24,7 @@ class SurgeMissingIDError(Exception):
 
 class SurgeMissingAttributeError(Exception):
     """Raise when a Surge object is missing a required attribute"""
+
     def __init__(self, message="Object is missing a required attribute."):
         self.message = message
         super().__init__(self.message)
@@ -28,6 +32,7 @@ class SurgeMissingAttributeError(Exception):
 
 class SurgeProjectQuestionError(Exception):
     """Raise for exceptions that occur when adding Questions to a new Project"""
+
     def __init__(
             self,
             message="All questions added to a Project must be of type Question."
@@ -38,6 +43,7 @@ class SurgeProjectQuestionError(Exception):
 
 class SurgeTaskDataError(Exception):
     """Raise for exceptions that occur when creating Task objects"""
+
     def __init__(
         self,
         message="Invalid argument: task_data must be a non-empty list of dicts."

--- a/surge/projects.py
+++ b/surge/projects.py
@@ -8,6 +8,7 @@ from surge import utils
 
 
 class Project(APIResource):
+
     def __init__(self, **kwargs):
         super().__init__()
         self.__dict__.update(kwargs)
@@ -36,7 +37,8 @@ class Project(APIResource):
         return self.print_attrs(forbid_list=["name", "id"])
 
     def _convert_questions_to_objects(self, questions_data):
-        return list(map(lambda params: Question.from_params(params), questions_data))
+        return list(
+            map(lambda params: Question.from_params(params), questions_data))
 
     @staticmethod
     def _validate_questions(questions):
@@ -103,7 +105,7 @@ class Project(APIResource):
             "tags": tags
         }
         if carousel is not None:
-            params = { **params, **carousel.to_dict() }
+            params = {**params, **carousel.to_dict()}
         if payment_per_response is not None:
             params["payment_per_response"] = payment_per_response
         response_json = cls.post(PROJECTS_ENDPOINT, params)
@@ -280,7 +282,6 @@ class Project(APIResource):
         '''
 
         params = {}
-
 
         if name is not None and len(name) > 0:
             params["name"] = name

--- a/surge/projects.py
+++ b/surge/projects.py
@@ -42,12 +42,14 @@ class Project(APIResource):
                 questions.append(
                     FreeResponseQuestion(
                         q["text"],
+                        id=q["id"],
                         required=q["required"],
                         preexisting_annotations=q["preexisting_annotations"]))
             elif q["type"] == "multiple_choice":
                 questions.append(
                     MultipleChoiceQuestion(
                         q["text"],
+                        id=q["id"],
                         options=q["options"],
                         required=q["required"],
                         preexisting_annotations=q["preexisting_annotations"],
@@ -56,6 +58,7 @@ class Project(APIResource):
             elif q["type"] == "checkbox":
                 questions.append(
                     CheckboxQuestion(q["text"],
+                                     id=q["id"],
                                      options=q["options"],
                                      required=q["required"],
                                      preexisting_annotations=q["preexisting_annotations"],
@@ -64,6 +67,7 @@ class Project(APIResource):
                 questions.append(
                     TextTaggingQuestion(
                         q["text"],
+                        id=q["id"],
                         required=q["required"],
                         options=q["options"],
                         preexisting_annotations=q["preexisting_annotations"],
@@ -76,6 +80,7 @@ class Project(APIResource):
                 questions.append(
                     TreeSelectionQuestion(
                         q["text"],
+                        id=q["id"],
                         options=q["options"],
                         required=q["required"],
                         preexisting_annotations=q["preexisting_annotations"],
@@ -84,6 +89,7 @@ class Project(APIResource):
                 questions.append(
                     RankingQuestion(
                         q["text"],
+                        id=q["id"],
                         options=q["options"],
                         required=q["required"],
                         preexisting_annotations=q["preexisting_annotations"],
@@ -91,14 +97,16 @@ class Project(APIResource):
             elif q["type"] == "file_upload":
                 questions.append(
                     FileUpload(q["text"],
+                               id=q["id"],
                                required=q["required"]))
             elif q["type"] == "text":
                 questions.append(
-                    TextArea(q["text"]))
+                    TextArea(q["text"], id=q["id"]))
             elif q["type"] == "chat":
                 questions.append(
                     ChatBot(
                         q["text"],
+                        id=q["id"],
                         options=q["options"],
                         endpoint_url=q["endpoint_url"],
                         endpoint_headers=q["endpoint_headers"],

--- a/surge/projects.py
+++ b/surge/projects.py
@@ -2,7 +2,7 @@ import dateutil.parser
 
 from surge.errors import SurgeMissingIDError, SurgeProjectQuestionError, SurgeMissingAttributeError
 from surge.api_resource import PROJECTS_ENDPOINT, APIResource
-from surge.questions import Question, FreeResponseQuestion, MultipleChoiceQuestion, CheckboxQuestion, TextTaggingQuestion, TreeSelectionQuestion, FileUpload, RankingQuestion, ChatBot, TextArea
+from surge.questions import Question
 from surge.tasks import Task
 from surge import utils
 
@@ -36,82 +36,7 @@ class Project(APIResource):
         return self.print_attrs(forbid_list=["name", "id"])
 
     def _convert_questions_to_objects(self, questions_data):
-        questions = []
-        for q in questions_data:
-            if q["type"] == "free_response":
-                questions.append(
-                    FreeResponseQuestion(
-                        q["text"],
-                        id=q["id"],
-                        required=q["required"],
-                        preexisting_annotations=q["preexisting_annotations"]))
-            elif q["type"] == "multiple_choice":
-                questions.append(
-                    MultipleChoiceQuestion(
-                        q["text"],
-                        id=q["id"],
-                        options=q["options"],
-                        required=q["required"],
-                        preexisting_annotations=q["preexisting_annotations"],
-                        require_tiebreaker=q["require_tie_breaker"]))
-
-            elif q["type"] == "checkbox":
-                questions.append(
-                    CheckboxQuestion(q["text"],
-                                     id=q["id"],
-                                     options=q["options"],
-                                     required=q["required"],
-                                     preexisting_annotations=q["preexisting_annotations"],
-                                     require_tiebreaker=q["require_tie_breaker"]))
-            elif q["type"] == "text_tagging":
-                questions.append(
-                    TextTaggingQuestion(
-                        q["text"],
-                        id=q["id"],
-                        required=q["required"],
-                        options=q["options"],
-                        preexisting_annotations=q["preexisting_annotations"],
-                        token_granularity=q["ner_token_granularity"],
-                        allow_relationship_tags=q["ner_allow_relationship_tags"],
-                        allow_overlapping_tags=q["ner_allow_overlapping_tags"],
-                        require_tiebreaker=q["require_tie_breaker"]))
-
-            elif q["type"] == "tree_selection":
-                questions.append(
-                    TreeSelectionQuestion(
-                        q["text"],
-                        id=q["id"],
-                        options=q["options"],
-                        required=q["required"],
-                        preexisting_annotations=q["preexisting_annotations"],
-                        require_tiebreaker=q["require_tie_breaker"]))
-            elif q["type"] == "ranking":
-                questions.append(
-                    RankingQuestion(
-                        q["text"],
-                        id=q["id"],
-                        options=q["options"],
-                        required=q["required"],
-                        preexisting_annotations=q["preexisting_annotations"],
-                        allow_ranking_ties=q["allow_ranking_ties"]))
-            elif q["type"] == "file_upload":
-                questions.append(
-                    FileUpload(q["text"],
-                               id=q["id"],
-                               required=q["required"]))
-            elif q["type"] == "text":
-                questions.append(
-                    TextArea(q["text"], id=q["id"]))
-            elif q["type"] == "chat":
-                questions.append(
-                    ChatBot(
-                        q["text"],
-                        id=q["id"],
-                        options=q["options"],
-                        endpoint_url=q["endpoint_url"],
-                        endpoint_headers=q["endpoint_headers"],
-                        preexisting_annotations=q["preexisting_annotations"]))
-        return questions
+        return list(map(lambda params: Question.from_params(params), questions_data))
 
     @staticmethod
     def _validate_questions(questions):

--- a/surge/questions.py
+++ b/surge/questions.py
@@ -2,7 +2,8 @@ import json
 
 
 class Question(object):
-    def __init__(self, text, type_=None, required=True, column_header=None):
+    def __init__(self, id, text, type_=None, required=True, column_header=None):
+        self.id = id
         self.text = text
         self.type = type_
         self.required = required
@@ -16,12 +17,13 @@ class Question(object):
 
 
 class FreeResponseQuestion(Question):
-    def __init__(self, text, required=True, preexisting_annotations=None, use_for_serial_collection=False, column_header=None):
+    def __init__(self, text, id=None, required=True, preexisting_annotations=None, use_for_serial_collection=False, column_header=None):
         '''
         Create a free response question.
 
         Args:
             text (string): Required. The instructions above the free text box, e.g. "Please explain your reasoning".
+            id (string): The UUID of this question, if it has been created. Otherwise, it will be None.
             required (boolean): Defaults to true. Whether or not workers must fill out this question before moving on to the next task.
             preexisting_annotations (string): You can use preexisting annotations to prepopulate text box an option specified in the task data.
                 The preexisting_annotations param should contain the task data key you are loading the default values from.
@@ -29,7 +31,7 @@ class FreeResponseQuestion(Question):
                 but will rather be used to collect the responses to a number of other items as a JSON string.
             column_header (string): This value will be used as the column header for the results table on the Surge AI site and in results CSV and JSON files.
         '''
-        super().__init__(text, type_="free_response", required=required, column_header=column_header)
+        super().__init__(id, text, type_="free_response", required=required, column_header=column_header)
         self.preexisting_annotations = preexisting_annotations
         self.use_for_serial_collection = use_for_serial_collection
 
@@ -38,6 +40,7 @@ class MultipleChoiceQuestion(Question):
     def __init__(
             self,
             text,
+            id=None,
             options=[],
             descriptions=[],
             required=True,
@@ -49,6 +52,7 @@ class MultipleChoiceQuestion(Question):
 
         Args:
             text (string): Required. The text of the question being asked, e.g. "Is the sentiment of this text positive or negative?"
+            id (string): The UUID of this question, if it has been created. Otherwise, it will be None.
             options (list of strings): Required. A list of the options for the radios, e.g. ["Yes", "No"].
             descriptions(list of strings): Tooltip text for the options. This should have the same length as the options.
                 You can substitute in empty strings if one option doesn't have a tooltip.
@@ -59,7 +63,7 @@ class MultipleChoiceQuestion(Question):
                 For example, imagine you are using two workers per task. If one selects Option A and the second one selections Option B a third will be assigned to the task to break the tie.
             column_header (string): This value will be used as the column header for the results table on the Surge AI site and in results CSV and JSON files.
         '''
-        super().__init__(text, type_="multiple_choice", required=required, column_header=column_header)
+        super().__init__(id, text, type_="multiple_choice", required=required, column_header=column_header)
         self.options = options
         self.descriptions = descriptions
         self.preexisting_annotations = preexisting_annotations
@@ -70,6 +74,7 @@ class CheckboxQuestion(Question):
     def __init__(
             self,
             text,
+            id=None,
             options=[],
             descriptions=[],
             required=True,
@@ -81,6 +86,7 @@ class CheckboxQuestion(Question):
 
         Args:
             text (string): Required. The text of the question being asked, e.g. "Check all the apply."
+            id (string): The UUID of this question, if it has been created. Otherwise, it will be None.
             options (list of strings): Required. A list of the options for the checkboxes.
             descriptions(list of strings): Tooltip text for the options. This should have the same length as the options.
                 You can substitute in empty strings if one option doesn't have a tooltip.
@@ -91,7 +97,7 @@ class CheckboxQuestion(Question):
                 For example, imagine you are using two workers per task. If one selects Option A and the second one selections Option B a third will be assigned to the task to break the tie.
             column_header (string): This value will be used as the column header for the results table on the Surge AI site and in results CSV and JSON files.
         '''
-        super().__init__(text, type_="checkbox", required=required, column_header=column_header)
+        super().__init__(id, text, type_="checkbox", required=required, column_header=column_header)
         self.options = options
         self.descriptions = descriptions
         self.preexisting_annotations = preexisting_annotations
@@ -102,6 +108,7 @@ class TextTaggingQuestion(Question):
     def __init__(
             self,
             text,
+            id=None,
             options=[],
             required=True,
             preexisting_annotations=None,
@@ -115,6 +122,7 @@ class TextTaggingQuestion(Question):
 
         Args:
             text (string): Required. The text that needs to be tagged.
+            id (string): The UUID of this question, if it has been created. Otherwise, it will be None.
             required (boolean): If true, worker must tag at least element.
             options (list of strings): Required. A list of tags that can be used to tag spans of text, e.g. ["Person", "Place"].
             preexisting_annotations (string): You can use preexisting annotations to prepopulate the named entity tagger. This must contain serialized JSON data
@@ -126,7 +134,7 @@ class TextTaggingQuestion(Question):
                 Workers must have the exact same set of tags to be considered in agreement.
             column_header (string): This value will be used as the column header for the results table on the Surge AI site and in results CSV and JSON files.
         '''
-        super().__init__(text, type_="text_tagging", required=required, column_header=column_header)
+        super().__init__(id, text, type_="text_tagging", required=required, column_header=column_header)
         self.options = options
         self.preexisting_annotations = preexisting_annotations
         self.token_granularity = token_granularity
@@ -139,6 +147,7 @@ class TreeSelectionQuestion(Question):
     def __init__(
             self,
             text,
+            id=None,
             options=[],
             descriptions=[],
             required=True,
@@ -150,6 +159,7 @@ class TreeSelectionQuestion(Question):
 
         Args:
             text (string): Required. The text of the question being asked, e.g. "Which category does this example belong to?"
+            id (string): The UUID of this question, if it has been created. Otherwise, it will be None.
             options (list of strings): Required. A list of the options for the tree. Each level of hierarchy should be separate by a " / ".
                 For example, one valid set of options would be ["1A / 2A", "1A / 2B", "1B / 2C", "1B / 2D"].
             descriptions(list of strings): Tooltip text for the options. This should have the same length as the options.
@@ -161,7 +171,7 @@ class TreeSelectionQuestion(Question):
                 For example, imagine you are using two workers per task. If one selects Option A and the second one selections Option B a third will be assigned to the task to break the tie.
             column_header (string): This value will be used as the column header for the results table on the Surge AI site and in results CSV and JSON files.
         '''
-        super().__init__(text, type_="tree_selection", required=required, column_header=column_header)
+        super().__init__(id, text, type_="tree_selection", required=required, column_header=column_header)
         self.options = options
         self.descriptions = descriptions
         self.preexisting_annotations = preexisting_annotations
@@ -169,22 +179,24 @@ class TreeSelectionQuestion(Question):
 
 
 class FileUpload(Question):
-    def __init__(self, text, required=False, column_header=None):
+    def __init__(self, text, id=None, required=False, column_header=None):
         '''
         Add a file upload widget where workers can upload images, documents, or other files.
 
         Args:
             text (string): This text will appear above the file upload and can be used to specify any instructions.
+            id (string): The UUID of this question, if it has been created. Otherwise, it will be None.
             required (boolean): If true, Surgers will be required to upload a file before moving on to the next task.
             column_header (string): This value will be used as the column header for the results table on the Surge AI site and in results CSV and JSON files.
         '''
-        super().__init__(text, type_="file_upload", required=required, column_header=column_header)
+        super().__init__(id, text, type_="file_upload", required=required, column_header=column_header)
 
 
 class RankingQuestion(Question):
     def __init__(
             self,
             text,
+            id=None,
             options=[],
             required=False,
             preexisting_annotations=None,
@@ -196,13 +208,14 @@ class RankingQuestion(Question):
         Args:
             required (boolean): If true, worker must rank at least one element.
             text (string): Required. The text of the question being asked, e.g. "Please rank these search results from best to worst"
+            id (string): The UUID of this question, if it has been created. Otherwise, it will be None.
             options (list of strings): Required. A list of the options being ranked.
             preexisting_annotations (string): You can use preexisting annotations to prepopulate the named entity tagger.
                 This must contain serialized data in the same format outputted by the ranking tool.
             allow_ranking_ties (boolean): Optional. Whether or not to allow ties in the ranking. If ties are allowed, two options can be ranked in the same group.
             column_header (string): This value will be used as the column header for the results table on the Surge AI site and in results CSV and JSON files.
         '''
-        super().__init__(text, type_="ranking", required=required, column_header=column_header)
+        super().__init__(id, text, type_="ranking", required=required, column_header=column_header)
         self.options = options
         self.allow_ranking_ties = allow_ranking_ties
 
@@ -211,6 +224,7 @@ class ChatBot(Question):
     def __init__(
             self,
             text,
+            id=None,
             options=[],
             endpoint_url=None,
             endpoint_headers=None,
@@ -222,12 +236,13 @@ class ChatBot(Question):
 
         Args:
             text (string): This text will appear above the chatbot and can be used to specify any instructions.
+            id (string): The UUID of this question, if it has been created. Otherwise, it will be None.
             options (list of strings): Options for rating chatbot responses.
             endpoint_url (string): A URL to send chat responses to. It must include a "text" field in its response.
             endpoint_headers (string): Please provide a JSON string with any headers that need to be set when calling this URL.
             column_header (string): This value will be used as the column header for the results table on the Surge AI site and in results CSV and JSON files.
         '''
-        super().__init__(text, type_="chat", required=required, column_header=column_header)
+        super().__init__(id, text, type_="chat", required=required, column_header=column_header)
         self.options = options
         self.endpoint_url = endpoint_url
         self.endpoint_headers = endpoint_headers
@@ -235,5 +250,5 @@ class ChatBot(Question):
 
 
 class TextArea(Question):
-    def __init__(self, text):
-        super().__init__(text, type_="text", required=False)
+    def __init__(self, text, id=None):
+        super().__init__(id, text, type_="text", required=False)

--- a/surge/questions.py
+++ b/surge/questions.py
@@ -3,7 +3,13 @@ from surge.api_resource import QUESTIONS_ENDPOINT, APIResource
 
 
 class Question(APIResource):
-    def __init__(self, id, text, type_=None, required=True, column_header=None):
+
+    def __init__(self,
+                 id,
+                 text,
+                 type_=None,
+                 required=True,
+                 column_header=None):
         self.id = id
         self.text = text
         self.type = type_
@@ -26,77 +32,79 @@ class Question(APIResource):
                 info.pop("updated_at", None)
         if q["type"] == "free_response":
             return FreeResponseQuestion(
-                    q["text"],
-                    id=q["id"],
-                    required=q["required"],
-                    preexisting_annotations=q["preexisting_annotations"],
-                    shown_by_option_id=q["shown_by_item_option_id"],
-                    hidden_by_option_id=q["hidden_by_item_option_id"])
+                q["text"],
+                id=q["id"],
+                required=q["required"],
+                preexisting_annotations=q["preexisting_annotations"],
+                shown_by_option_id=q["shown_by_item_option_id"],
+                hidden_by_option_id=q["hidden_by_item_option_id"])
         elif q["type"] == "multiple_choice":
             return MultipleChoiceQuestion(
-                    q["text"],
-                    id=q["id"],
-                    options=q["options"],
-                    options_info=options_info,
-                    required=q["required"],
-                    preexisting_annotations=q["preexisting_annotations"],
-                    require_tiebreaker=q["require_tie_breaker"],
-                    shown_by_option_id=q["shown_by_item_option_id"],
-                    hidden_by_option_id=q["hidden_by_item_option_id"])
+                q["text"],
+                id=q["id"],
+                options=q["options"],
+                options_info=options_info,
+                required=q["required"],
+                preexisting_annotations=q["preexisting_annotations"],
+                require_tiebreaker=q["require_tie_breaker"],
+                shown_by_option_id=q["shown_by_item_option_id"],
+                hidden_by_option_id=q["hidden_by_item_option_id"])
 
         elif q["type"] == "checkbox":
-            return CheckboxQuestion(q["text"],
-                                 id=q["id"],
-                                 options=q["options"],
-                                 options_info=options_info,
-                                 required=q["required"],
-                                 preexisting_annotations=q["preexisting_annotations"],
-                                 require_tiebreaker=q["require_tie_breaker"],
-                                 shown_by_option_id=q["shown_by_item_option_id"],
-                                 hidden_by_option_id=q["hidden_by_item_option_id"])
+            return CheckboxQuestion(
+                q["text"],
+                id=q["id"],
+                options=q["options"],
+                options_info=options_info,
+                required=q["required"],
+                preexisting_annotations=q["preexisting_annotations"],
+                require_tiebreaker=q["require_tie_breaker"],
+                shown_by_option_id=q["shown_by_item_option_id"],
+                hidden_by_option_id=q["hidden_by_item_option_id"])
         elif q["type"] == "text_tagging":
             return TextTaggingQuestion(
-                    q["text"],
-                    id=q["id"],
-                    required=q["required"],
-                    options=q["options"],
-                    options_info=options_info,
-                    preexisting_annotations=q["preexisting_annotations"],
-                    token_granularity=q["ner_token_granularity"],
-                    allow_relationship_tags=q["ner_allow_relationship_tags"],
-                    allow_overlapping_tags=q["ner_allow_overlapping_tags"],
-                    require_tiebreaker=q["require_tie_breaker"],
-                    shown_by_option_id=q["shown_by_item_option_id"],
-                    hidden_by_option_id=q["hidden_by_item_option_id"])
+                q["text"],
+                id=q["id"],
+                required=q["required"],
+                options=q["options"],
+                options_info=options_info,
+                preexisting_annotations=q["preexisting_annotations"],
+                token_granularity=q["ner_token_granularity"],
+                allow_relationship_tags=q["ner_allow_relationship_tags"],
+                allow_overlapping_tags=q["ner_allow_overlapping_tags"],
+                require_tiebreaker=q["require_tie_breaker"],
+                shown_by_option_id=q["shown_by_item_option_id"],
+                hidden_by_option_id=q["hidden_by_item_option_id"])
 
         elif q["type"] == "tree_selection":
             return TreeSelectionQuestion(
-                    q["text"],
-                    id=q["id"],
-                    options=q["options"],
-                    options_info=options_info,
-                    required=q["required"],
-                    preexisting_annotations=q["preexisting_annotations"],
-                    require_tiebreaker=q["require_tie_breaker"],
-                    shown_by_option_id=q["shown_by_item_option_id"],
-                    hidden_by_option_id=q["hidden_by_item_option_id"])
+                q["text"],
+                id=q["id"],
+                options=q["options"],
+                options_info=options_info,
+                required=q["required"],
+                preexisting_annotations=q["preexisting_annotations"],
+                require_tiebreaker=q["require_tie_breaker"],
+                shown_by_option_id=q["shown_by_item_option_id"],
+                hidden_by_option_id=q["hidden_by_item_option_id"])
         elif q["type"] == "ranking":
             return RankingQuestion(
-                    q["text"],
-                    id=q["id"],
-                    options=q["options"],
-                    options_info=options_info,
-                    required=q["required"],
-                    preexisting_annotations=q["preexisting_annotations"],
-                    allow_ranking_ties=q["allow_ranking_ties"],
-                    shown_by_option_id=q["shown_by_item_option_id"],
-                    hidden_by_option_id=q["hidden_by_item_option_id"])
+                q["text"],
+                id=q["id"],
+                options=q["options"],
+                options_info=options_info,
+                required=q["required"],
+                preexisting_annotations=q["preexisting_annotations"],
+                allow_ranking_ties=q["allow_ranking_ties"],
+                shown_by_option_id=q["shown_by_item_option_id"],
+                hidden_by_option_id=q["hidden_by_item_option_id"])
         elif q["type"] == "file_upload":
-            return FileUpload(q["text"],
-                           id=q["id"],
-                           required=q["required"],
-                           shown_by_option_id=q["shown_by_item_option_id"],
-                           hidden_by_option_id=q["hidden_by_item_option_id"])
+            return FileUpload(
+                q["text"],
+                id=q["id"],
+                required=q["required"],
+                shown_by_option_id=q["shown_by_item_option_id"],
+                hidden_by_option_id=q["hidden_by_item_option_id"])
         elif q["type"] == "text":
             return TextArea(q["text"],
                             id=q["id"],
@@ -104,15 +112,15 @@ class Question(APIResource):
                             hidden_by_option_id=q["hidden_by_item_option_id"])
         elif q["type"] == "chat":
             return ChatBot(
-                    q["text"],
-                    id=q["id"],
-                    options=q["options"],
-                    options_info=options_info,
-                    endpoint_url=q["endpoint_url"],
-                    endpoint_headers=q["endpoint_headers"],
-                    preexisting_annotations=q["preexisting_annotations"],
-                    shown_by_option_id=q["shown_by_item_option_id"],
-                    hidden_by_option_id=q["hidden_by_item_option_id"])
+                q["text"],
+                id=q["id"],
+                options=q["options"],
+                options_info=options_info,
+                endpoint_url=q["endpoint_url"],
+                endpoint_headers=q["endpoint_headers"],
+                preexisting_annotations=q["preexisting_annotations"],
+                shown_by_option_id=q["shown_by_item_option_id"],
+                hidden_by_option_id=q["hidden_by_item_option_id"])
 
     def update(self,
                text: str = None,
@@ -133,16 +141,16 @@ class Question(APIResource):
 
 
 class FreeResponseQuestion(Question):
-    def __init__(
-            self,
-            text,
-            id=None,
-            required=True,
-            preexisting_annotations=None,
-            use_for_serial_collection=False,
-            column_header=None,
-            hidden_by_option_id=None,
-            shown_by_option_id=None):
+
+    def __init__(self,
+                 text,
+                 id=None,
+                 required=True,
+                 preexisting_annotations=None,
+                 use_for_serial_collection=False,
+                 column_header=None,
+                 hidden_by_option_id=None,
+                 shown_by_option_id=None):
         '''
         Create a free response question.
 
@@ -158,7 +166,11 @@ class FreeResponseQuestion(Question):
             hidden_by_option_id (string): If set, this question will be visible by default but hidden when the option with the provided id is selected.
             shown_by_option_id (string). If set, this question will be hidden by default but shown when the option with the provided id is selected.
         '''
-        super().__init__(id, text, type_="free_response", required=required, column_header=column_header)
+        super().__init__(id,
+                         text,
+                         type_="free_response",
+                         required=required,
+                         column_header=column_header)
         self.preexisting_annotations = preexisting_annotations
         self.use_for_serial_collection = use_for_serial_collection
         self.hidden_by_option_id = hidden_by_option_id
@@ -166,19 +178,19 @@ class FreeResponseQuestion(Question):
 
 
 class MultipleChoiceQuestion(Question):
-    def __init__(
-            self,
-            text,
-            id=None,
-            options=[],
-            options_info=None,
-            descriptions=[],
-            required=True,
-            preexisting_annotations=None,
-            require_tiebreaker=False,
-            column_header=None,
-            hidden_by_option_id=None,
-            shown_by_option_id=None):
+
+    def __init__(self,
+                 text,
+                 id=None,
+                 options=[],
+                 options_info=None,
+                 descriptions=[],
+                 required=True,
+                 preexisting_annotations=None,
+                 require_tiebreaker=False,
+                 column_header=None,
+                 hidden_by_option_id=None,
+                 shown_by_option_id=None):
         '''
         Create a multiple choice radio question.
 
@@ -198,7 +210,11 @@ class MultipleChoiceQuestion(Question):
             hidden_by_option_id (string): If set, this question will be visible by default but hidden when the option with the provided id is selected.
             shown_by_option_id (string). If set, this question will be hidden by default but shown when the option with the provided id is selected.
         '''
-        super().__init__(id, text, type_="multiple_choice", required=required, column_header=column_header)
+        super().__init__(id,
+                         text,
+                         type_="multiple_choice",
+                         required=required,
+                         column_header=column_header)
         self.options = options
         self.options_info = options_info
         self.descriptions = descriptions
@@ -209,19 +225,19 @@ class MultipleChoiceQuestion(Question):
 
 
 class CheckboxQuestion(Question):
-    def __init__(
-            self,
-            text,
-            id=None,
-            options=[],
-            options_info=None,
-            descriptions=[],
-            required=True,
-            preexisting_annotations=None,
-            require_tiebreaker=False,
-            column_header=None,
-            hidden_by_option_id=None,
-            shown_by_option_id=None):
+
+    def __init__(self,
+                 text,
+                 id=None,
+                 options=[],
+                 options_info=None,
+                 descriptions=[],
+                 required=True,
+                 preexisting_annotations=None,
+                 require_tiebreaker=False,
+                 column_header=None,
+                 hidden_by_option_id=None,
+                 shown_by_option_id=None):
         '''
         Create a checkbox question. Unlike a multiple choice question, it's possible to select multiple checkboxes.
 
@@ -241,7 +257,11 @@ class CheckboxQuestion(Question):
             hidden_by_option_id (string): If set, this question will be visible by default but hidden when the option with the provided id is selected.
             shown_by_option_id (string). If set, this question will be hidden by default but shown when the option with the provided id is selected.
         '''
-        super().__init__(id, text, type_="checkbox", required=required, column_header=column_header)
+        super().__init__(id,
+                         text,
+                         type_="checkbox",
+                         required=required,
+                         column_header=column_header)
         self.options = options
         self.options_info = options_info
         self.descriptions = descriptions
@@ -252,21 +272,21 @@ class CheckboxQuestion(Question):
 
 
 class TextTaggingQuestion(Question):
-    def __init__(
-            self,
-            text,
-            id=None,
-            options=[],
-            options_info=None,
-            required=True,
-            preexisting_annotations=None,
-            token_granularity=True,
-            allow_relationship_tags=False,
-            allow_overlapping_tags=False,
-            require_tiebreaker=False,
-            column_header=None,
-            hidden_by_option_id=None,
-            shown_by_option_id=None):
+
+    def __init__(self,
+                 text,
+                 id=None,
+                 options=[],
+                 options_info=None,
+                 required=True,
+                 preexisting_annotations=None,
+                 token_granularity=True,
+                 allow_relationship_tags=False,
+                 allow_overlapping_tags=False,
+                 require_tiebreaker=False,
+                 column_header=None,
+                 hidden_by_option_id=None,
+                 shown_by_option_id=None):
         '''
         Create a text tagging (NER) question. Unlikely a multiple choice question, it's possible to select multiple checkboxes
 
@@ -287,7 +307,11 @@ class TextTaggingQuestion(Question):
             hidden_by_option_id (string): If set, this question will be visible by default but hidden when the option with the provided id is selected.
             shown_by_option_id (string). If set, this question will be hidden by default but shown when the option with the provided id is selected.
         '''
-        super().__init__(id, text, type_="text_tagging", required=required, column_header=column_header)
+        super().__init__(id,
+                         text,
+                         type_="text_tagging",
+                         required=required,
+                         column_header=column_header)
         self.options = options
         self.options_info = options_info
         self.preexisting_annotations = preexisting_annotations
@@ -300,19 +324,19 @@ class TextTaggingQuestion(Question):
 
 
 class TreeSelectionQuestion(Question):
-    def __init__(
-            self,
-            text,
-            id=None,
-            options=[],
-            options_info=None,
-            descriptions=[],
-            required=True,
-            preexisting_annotations=None,
-            require_tiebreaker=False,
-            column_header=None,
-            hidden_by_option_id=None,
-            shown_by_option_id=None):
+
+    def __init__(self,
+                 text,
+                 id=None,
+                 options=[],
+                 options_info=None,
+                 descriptions=[],
+                 required=True,
+                 preexisting_annotations=None,
+                 require_tiebreaker=False,
+                 column_header=None,
+                 hidden_by_option_id=None,
+                 shown_by_option_id=None):
         '''
         Create a hierarchical multiple choice question. This is useful if you have a lot of options in a nested format.
 
@@ -333,7 +357,11 @@ class TreeSelectionQuestion(Question):
             hidden_by_option_id (string): If set, this question will be visible by default but hidden when the option with the provided id is selected.
             shown_by_option_id (string). If set, this question will be hidden by default but shown when the option with the provided id is selected.
         '''
-        super().__init__(id, text, type_="tree_selection", required=required, column_header=column_header)
+        super().__init__(id,
+                         text,
+                         type_="tree_selection",
+                         required=required,
+                         column_header=column_header)
         self.options = options
         self.options_info = options_info
         self.descriptions = descriptions
@@ -344,14 +372,14 @@ class TreeSelectionQuestion(Question):
 
 
 class FileUpload(Question):
-    def __init__(
-            self,
-            text,
-            id=None,
-            required=False,
-            column_header=None,
-            hidden_by_option_id=None,
-            shown_by_option_id=None):
+
+    def __init__(self,
+                 text,
+                 id=None,
+                 required=False,
+                 column_header=None,
+                 hidden_by_option_id=None,
+                 shown_by_option_id=None):
         '''
         Add a file upload widget where workers can upload images, documents, or other files.
 
@@ -363,24 +391,28 @@ class FileUpload(Question):
             hidden_by_option_id (string): If set, this question will be visible by default but hidden when the option with the provided id is selected.
             shown_by_option_id (string). If set, this question will be hidden by default but shown when the option with the provided id is selected.
         '''
-        super().__init__(id, text, type_="file_upload", required=required, column_header=column_header)
+        super().__init__(id,
+                         text,
+                         type_="file_upload",
+                         required=required,
+                         column_header=column_header)
         self.hidden_by_option_id = hidden_by_option_id
         self.shown_by_option_id = shown_by_option_id
 
 
 class RankingQuestion(Question):
-    def __init__(
-            self,
-            text,
-            id=None,
-            options=[],
-            options_info=None,
-            required=False,
-            preexisting_annotations=None,
-            allow_ranking_ties=False,
-            column_header=None,
-            hidden_by_option_id=None,
-            shown_by_option_id=None):
+
+    def __init__(self,
+                 text,
+                 id=None,
+                 options=[],
+                 options_info=None,
+                 required=False,
+                 preexisting_annotations=None,
+                 allow_ranking_ties=False,
+                 column_header=None,
+                 hidden_by_option_id=None,
+                 shown_by_option_id=None):
         '''
         Create a ranking widget. Workers can drag and drop the option to specify their ranking.
 
@@ -397,7 +429,11 @@ class RankingQuestion(Question):
             hidden_by_option_id (string): If set, this question will be visible by default but hidden when the option with the provided id is selected.
             shown_by_option_id (string). If set, this question will be hidden by default but shown when the option with the provided id is selected.
         '''
-        super().__init__(id, text, type_="ranking", required=required, column_header=column_header)
+        super().__init__(id,
+                         text,
+                         type_="ranking",
+                         required=required,
+                         column_header=column_header)
         self.options = options
         self.options_info = options_info
         self.allow_ranking_ties = allow_ranking_ties
@@ -406,19 +442,19 @@ class RankingQuestion(Question):
 
 
 class ChatBot(Question):
-    def __init__(
-            self,
-            text,
-            id=None,
-            options=[],
-            options_info=None,
-            endpoint_url=None,
-            endpoint_headers=None,
-            preexisting_annotations=None,
-            required=False,
-            column_header=None,
-            hidden_by_option_id=None,
-            shown_by_option_id=None):
+
+    def __init__(self,
+                 text,
+                 id=None,
+                 options=[],
+                 options_info=None,
+                 endpoint_url=None,
+                 endpoint_headers=None,
+                 preexisting_annotations=None,
+                 required=False,
+                 column_header=None,
+                 hidden_by_option_id=None,
+                 shown_by_option_id=None):
         '''
         Create an interactive chatbot on the labeling page. This is an advanced item type.
 
@@ -433,23 +469,27 @@ class ChatBot(Question):
             hidden_by_option_id (string): If set, this question will be visible by default but hidden when the option with the provided id is selected.
             shown_by_option_id (string). If set, this question will be hidden by default but shown when the option with the provided id is selected.
         '''
-        super().__init__(id, text, type_="chat", required=required, column_header=column_header)
+        super().__init__(id,
+                         text,
+                         type_="chat",
+                         required=required,
+                         column_header=column_header)
         self.options = options
         self.options_info = options_info
         self.endpoint_url = endpoint_url
         self.endpoint_headers = endpoint_headers
-        self.preexisting_annotations=preexisting_annotations
+        self.preexisting_annotations = preexisting_annotations
         self.hidden_by_option_id = hidden_by_option_id
         self.shown_by_option_id = shown_by_option_id
 
 
 class TextArea(Question):
-    def __init__(
-            self,
-            text,
-            id=None,
-            hidden_by_option_id=None,
-            shown_by_option_id=None):
+
+    def __init__(self,
+                 text,
+                 id=None,
+                 hidden_by_option_id=None,
+                 shown_by_option_id=None):
         super().__init__(id, text, type_="text", required=False)
         self.hidden_by_option_id = hidden_by_option_id
         self.shown_by_option_id = shown_by_option_id

--- a/surge/questions.py
+++ b/surge/questions.py
@@ -18,83 +18,114 @@ class Question(APIResource):
 
     @classmethod
     def from_params(cls, q):
+        options_info = q["options_objects"] if "options_objects" in q else None
+        if options_info:
+            for info in options_info:
+                # We don't need to provide created_at / updated_at.
+                info.pop("created_at", None)
+                info.pop("updated_at", None)
         if q["type"] == "free_response":
             return FreeResponseQuestion(
                     q["text"],
                     id=q["id"],
                     required=q["required"],
-                    preexisting_annotations=q["preexisting_annotations"])
+                    preexisting_annotations=q["preexisting_annotations"],
+                    shown_by_option_id=q["shown_by_item_option_id"],
+                    hidden_by_option_id=q["hidden_by_item_option_id"])
         elif q["type"] == "multiple_choice":
             return MultipleChoiceQuestion(
                     q["text"],
                     id=q["id"],
                     options=q["options"],
+                    options_info=options_info,
                     required=q["required"],
                     preexisting_annotations=q["preexisting_annotations"],
-                    require_tiebreaker=q["require_tie_breaker"])
+                    require_tiebreaker=q["require_tie_breaker"],
+                    shown_by_option_id=q["shown_by_item_option_id"],
+                    hidden_by_option_id=q["hidden_by_item_option_id"])
 
         elif q["type"] == "checkbox":
             return CheckboxQuestion(q["text"],
                                  id=q["id"],
                                  options=q["options"],
+                                 options_info=options_info,
                                  required=q["required"],
                                  preexisting_annotations=q["preexisting_annotations"],
-                                 require_tiebreaker=q["require_tie_breaker"])
+                                 require_tiebreaker=q["require_tie_breaker"],
+                                 shown_by_option_id=q["shown_by_item_option_id"],
+                                 hidden_by_option_id=q["hidden_by_item_option_id"])
         elif q["type"] == "text_tagging":
             return TextTaggingQuestion(
                     q["text"],
                     id=q["id"],
                     required=q["required"],
                     options=q["options"],
+                    options_info=options_info,
                     preexisting_annotations=q["preexisting_annotations"],
                     token_granularity=q["ner_token_granularity"],
                     allow_relationship_tags=q["ner_allow_relationship_tags"],
                     allow_overlapping_tags=q["ner_allow_overlapping_tags"],
-                    require_tiebreaker=q["require_tie_breaker"])
+                    require_tiebreaker=q["require_tie_breaker"],
+                    shown_by_option_id=q["shown_by_item_option_id"],
+                    hidden_by_option_id=q["hidden_by_item_option_id"])
 
         elif q["type"] == "tree_selection":
             return TreeSelectionQuestion(
                     q["text"],
                     id=q["id"],
                     options=q["options"],
+                    options_info=options_info,
                     required=q["required"],
                     preexisting_annotations=q["preexisting_annotations"],
-                    require_tiebreaker=q["require_tie_breaker"])
+                    require_tiebreaker=q["require_tie_breaker"],
+                    shown_by_option_id=q["shown_by_item_option_id"],
+                    hidden_by_option_id=q["hidden_by_item_option_id"])
         elif q["type"] == "ranking":
             return RankingQuestion(
                     q["text"],
                     id=q["id"],
                     options=q["options"],
+                    options_info=options_info,
                     required=q["required"],
                     preexisting_annotations=q["preexisting_annotations"],
-                    allow_ranking_ties=q["allow_ranking_ties"])
+                    allow_ranking_ties=q["allow_ranking_ties"],
+                    shown_by_option_id=q["shown_by_item_option_id"],
+                    hidden_by_option_id=q["hidden_by_item_option_id"])
         elif q["type"] == "file_upload":
             return FileUpload(q["text"],
                            id=q["id"],
-                           required=q["required"])
+                           required=q["required"],
+                           shown_by_option_id=q["shown_by_item_option_id"],
+                           hidden_by_option_id=q["hidden_by_item_option_id"])
         elif q["type"] == "text":
-            return TextArea(q["text"], id=q["id"])
+            return TextArea(q["text"],
+                            id=q["id"],
+                            shown_by_option_id=q["shown_by_item_option_id"],
+                            hidden_by_option_id=q["hidden_by_item_option_id"])
         elif q["type"] == "chat":
             return ChatBot(
                     q["text"],
                     id=q["id"],
                     options=q["options"],
+                    options_info=options_info,
                     endpoint_url=q["endpoint_url"],
                     endpoint_headers=q["endpoint_headers"],
-                    preexisting_annotations=q["preexisting_annotations"])
+                    preexisting_annotations=q["preexisting_annotations"],
+                    shown_by_option_id=q["shown_by_item_option_id"],
+                    hidden_by_option_id=q["hidden_by_item_option_id"])
 
     def update(self,
                text: str = None,
-               hidden_by_item_option_id: str = None,
-               shown_by_item_option_id: str = None):
+               hidden_by_option_id: str = None,
+               shown_by_option_id: str = None):
         params = {}
 
         if text is not None:
             params["text"] = text
         if hidden_by_item_option_id is not None:
-            params["hidden_by_item_option_id"] = hidden_by_item_option_id
+            params["hidden_by_item_option_id"] = hidden_by_option_id
         if shown_by_item_option_id is not None:
-            params["shown_by_item_option_id"] = shown_by_item_option_id
+            params["shown_by_item_option_id"] = shown_by_option_id
 
         endpoint = f"{QUESTIONS_ENDPOINT}/{self.id}"
         response_json = self.put(endpoint, params)
@@ -102,7 +133,16 @@ class Question(APIResource):
 
 
 class FreeResponseQuestion(Question):
-    def __init__(self, text, id=None, required=True, preexisting_annotations=None, use_for_serial_collection=False, column_header=None):
+    def __init__(
+            self,
+            text,
+            id=None,
+            required=True,
+            preexisting_annotations=None,
+            use_for_serial_collection=False,
+            column_header=None,
+            hidden_by_option_id=None,
+            shown_by_option_id=None):
         '''
         Create a free response question.
 
@@ -115,10 +155,14 @@ class FreeResponseQuestion(Question):
             use_for_serial_collection (boolean): Deprecated in favor of carousel. The free response question will not be shown to the user,
                 but will rather be used to collect the responses to a number of other items as a JSON string.
             column_header (string): This value will be used as the column header for the results table on the Surge AI site and in results CSV and JSON files.
+            hidden_by_option_id (string): If set, this question will be visible by default but hidden when the option with the provided id is selected.
+            shown_by_option_id (string). If set, this question will be hidden by default but shown when the option with the provided id is selected.
         '''
         super().__init__(id, text, type_="free_response", required=required, column_header=column_header)
         self.preexisting_annotations = preexisting_annotations
         self.use_for_serial_collection = use_for_serial_collection
+        self.hidden_by_option_id = hidden_by_option_id
+        self.shown_by_option_id = shown_by_option_id
 
 
 class MultipleChoiceQuestion(Question):
@@ -127,11 +171,14 @@ class MultipleChoiceQuestion(Question):
             text,
             id=None,
             options=[],
+            options_info=None,
             descriptions=[],
             required=True,
             preexisting_annotations=None,
             require_tiebreaker=False,
-            column_header=None):
+            column_header=None,
+            hidden_by_option_id=None,
+            shown_by_option_id=None):
         '''
         Create a multiple choice radio question.
 
@@ -139,6 +186,7 @@ class MultipleChoiceQuestion(Question):
             text (string): Required. The text of the question being asked, e.g. "Is the sentiment of this text positive or negative?"
             id (string): The UUID of this question, if it has been created. Otherwise, it will be None.
             options (list of strings): Required. A list of the options for the radios, e.g. ["Yes", "No"].
+            options_info (list of objects): Additional information about the options if the question has already been created. Otherwise, it will be None.
             descriptions(list of strings): Tooltip text for the options. This should have the same length as the options.
                 You can substitute in empty strings if one option doesn't have a tooltip.
             required (boolean): Defaults to true. Whether or not workers must fill out this question before moving on to the next task.
@@ -147,12 +195,17 @@ class MultipleChoiceQuestion(Question):
             require_tiebreaker (boolean): If set to true, more workers will be assigned to this task if fewer than 50% agree on an answer.
                 For example, imagine you are using two workers per task. If one selects Option A and the second one selections Option B a third will be assigned to the task to break the tie.
             column_header (string): This value will be used as the column header for the results table on the Surge AI site and in results CSV and JSON files.
+            hidden_by_option_id (string): If set, this question will be visible by default but hidden when the option with the provided id is selected.
+            shown_by_option_id (string). If set, this question will be hidden by default but shown when the option with the provided id is selected.
         '''
         super().__init__(id, text, type_="multiple_choice", required=required, column_header=column_header)
         self.options = options
+        self.options_info = options_info
         self.descriptions = descriptions
         self.preexisting_annotations = preexisting_annotations
         self.require_tiebreaker = require_tiebreaker
+        self.hidden_by_option_id = hidden_by_option_id
+        self.shown_by_option_id = shown_by_option_id
 
 
 class CheckboxQuestion(Question):
@@ -161,11 +214,14 @@ class CheckboxQuestion(Question):
             text,
             id=None,
             options=[],
+            options_info=None,
             descriptions=[],
             required=True,
             preexisting_annotations=None,
             require_tiebreaker=False,
-            column_header=None):
+            column_header=None,
+            hidden_by_option_id=None,
+            shown_by_option_id=None):
         '''
         Create a checkbox question. Unlike a multiple choice question, it's possible to select multiple checkboxes.
 
@@ -173,6 +229,7 @@ class CheckboxQuestion(Question):
             text (string): Required. The text of the question being asked, e.g. "Check all the apply."
             id (string): The UUID of this question, if it has been created. Otherwise, it will be None.
             options (list of strings): Required. A list of the options for the checkboxes.
+            options_info (list of objects): Additional information about the options if the question has already been created. Otherwise, it will be None.
             descriptions(list of strings): Tooltip text for the options. This should have the same length as the options.
                 You can substitute in empty strings if one option doesn't have a tooltip.
             required (boolean): Defaults to true. Whether or not workers must fill out this question before moving on to the next task.
@@ -181,12 +238,17 @@ class CheckboxQuestion(Question):
             require_tiebreaker (boolean): If set to true, more workers will be assigned to this task if fewer than 50% agree on an answer.
                 For example, imagine you are using two workers per task. If one selects Option A and the second one selections Option B a third will be assigned to the task to break the tie.
             column_header (string): This value will be used as the column header for the results table on the Surge AI site and in results CSV and JSON files.
+            hidden_by_option_id (string): If set, this question will be visible by default but hidden when the option with the provided id is selected.
+            shown_by_option_id (string). If set, this question will be hidden by default but shown when the option with the provided id is selected.
         '''
         super().__init__(id, text, type_="checkbox", required=required, column_header=column_header)
         self.options = options
+        self.options_info = options_info
         self.descriptions = descriptions
         self.preexisting_annotations = preexisting_annotations
         self.require_tiebreaker = require_tiebreaker
+        self.hidden_by_option_id = hidden_by_option_id
+        self.shown_by_option_id = shown_by_option_id
 
 
 class TextTaggingQuestion(Question):
@@ -195,13 +257,16 @@ class TextTaggingQuestion(Question):
             text,
             id=None,
             options=[],
+            options_info=None,
             required=True,
             preexisting_annotations=None,
             token_granularity=True,
             allow_relationship_tags=False,
             allow_overlapping_tags=False,
             require_tiebreaker=False,
-            column_header=None):
+            column_header=None,
+            hidden_by_option_id=None,
+            shown_by_option_id=None):
         '''
         Create a text tagging (NER) question. Unlikely a multiple choice question, it's possible to select multiple checkboxes
 
@@ -210,6 +275,7 @@ class TextTaggingQuestion(Question):
             id (string): The UUID of this question, if it has been created. Otherwise, it will be None.
             required (boolean): If true, worker must tag at least element.
             options (list of strings): Required. A list of tags that can be used to tag spans of text, e.g. ["Person", "Place"].
+            options_info (list of objects): Additional information about the options if the question has already been created. Otherwise, it will be None.
             preexisting_annotations (string): You can use preexisting annotations to prepopulate the named entity tagger. This must contain serialized JSON data
                 in the same format outputted by the text tagging tool.
             token_granularity (boolean): If set to true, spans will snap to the nearest word to prevent workers from accidentally tagging parts of words.
@@ -218,14 +284,19 @@ class TextTaggingQuestion(Question):
             require_tiebreaker (boolean): If set to true, more workers will be assigned to this task if fewer than 50% agree on an answer.
                 Workers must have the exact same set of tags to be considered in agreement.
             column_header (string): This value will be used as the column header for the results table on the Surge AI site and in results CSV and JSON files.
+            hidden_by_option_id (string): If set, this question will be visible by default but hidden when the option with the provided id is selected.
+            shown_by_option_id (string). If set, this question will be hidden by default but shown when the option with the provided id is selected.
         '''
         super().__init__(id, text, type_="text_tagging", required=required, column_header=column_header)
         self.options = options
+        self.options_info = options_info
         self.preexisting_annotations = preexisting_annotations
         self.token_granularity = token_granularity
         self.allow_relationship_tags = allow_relationship_tags
         self.allow_overlapping_tags = allow_overlapping_tags
         self.require_tiebreaker = require_tiebreaker
+        self.hidden_by_option_id = hidden_by_option_id
+        self.shown_by_option_id = shown_by_option_id
 
 
 class TreeSelectionQuestion(Question):
@@ -234,11 +305,14 @@ class TreeSelectionQuestion(Question):
             text,
             id=None,
             options=[],
+            options_info=None,
             descriptions=[],
             required=True,
             preexisting_annotations=None,
             require_tiebreaker=False,
-            column_header=None):
+            column_header=None,
+            hidden_by_option_id=None,
+            shown_by_option_id=None):
         '''
         Create a hierarchical multiple choice question. This is useful if you have a lot of options in a nested format.
 
@@ -247,6 +321,7 @@ class TreeSelectionQuestion(Question):
             id (string): The UUID of this question, if it has been created. Otherwise, it will be None.
             options (list of strings): Required. A list of the options for the tree. Each level of hierarchy should be separate by a " / ".
                 For example, one valid set of options would be ["1A / 2A", "1A / 2B", "1B / 2C", "1B / 2D"].
+            options_info (list of objects): Additional information about the options if the question has already been created. Otherwise, it will be None.
             descriptions(list of strings): Tooltip text for the options. This should have the same length as the options.
                 You can substitute in empty strings if one option doesn't have a tooltip.
             required (boolean): Defaults to true. Whether or not workers must fill out this question before moving on to the next task.
@@ -255,16 +330,28 @@ class TreeSelectionQuestion(Question):
             require_tiebreaker (boolean): If set to true, more workers will be assigned to this task if fewer than 50% agree on an answer.
                 For example, imagine you are using two workers per task. If one selects Option A and the second one selections Option B a third will be assigned to the task to break the tie.
             column_header (string): This value will be used as the column header for the results table on the Surge AI site and in results CSV and JSON files.
+            hidden_by_option_id (string): If set, this question will be visible by default but hidden when the option with the provided id is selected.
+            shown_by_option_id (string). If set, this question will be hidden by default but shown when the option with the provided id is selected.
         '''
         super().__init__(id, text, type_="tree_selection", required=required, column_header=column_header)
         self.options = options
+        self.options_info = options_info
         self.descriptions = descriptions
         self.preexisting_annotations = preexisting_annotations
         self.require_tiebreaker = require_tiebreaker
+        self.hidden_by_option_id = hidden_by_option_id
+        self.shown_by_option_id = shown_by_option_id
 
 
 class FileUpload(Question):
-    def __init__(self, text, id=None, required=False, column_header=None):
+    def __init__(
+            self,
+            text,
+            id=None,
+            required=False,
+            column_header=None,
+            hidden_by_option_id=None,
+            shown_by_option_id=None):
         '''
         Add a file upload widget where workers can upload images, documents, or other files.
 
@@ -273,8 +360,12 @@ class FileUpload(Question):
             id (string): The UUID of this question, if it has been created. Otherwise, it will be None.
             required (boolean): If true, Surgers will be required to upload a file before moving on to the next task.
             column_header (string): This value will be used as the column header for the results table on the Surge AI site and in results CSV and JSON files.
+            hidden_by_option_id (string): If set, this question will be visible by default but hidden when the option with the provided id is selected.
+            shown_by_option_id (string). If set, this question will be hidden by default but shown when the option with the provided id is selected.
         '''
         super().__init__(id, text, type_="file_upload", required=required, column_header=column_header)
+        self.hidden_by_option_id = hidden_by_option_id
+        self.shown_by_option_id = shown_by_option_id
 
 
 class RankingQuestion(Question):
@@ -283,10 +374,13 @@ class RankingQuestion(Question):
             text,
             id=None,
             options=[],
+            options_info=None,
             required=False,
             preexisting_annotations=None,
             allow_ranking_ties=False,
-            column_header=None):
+            column_header=None,
+            hidden_by_option_id=None,
+            shown_by_option_id=None):
         '''
         Create a ranking widget. Workers can drag and drop the option to specify their ranking.
 
@@ -295,14 +389,20 @@ class RankingQuestion(Question):
             text (string): Required. The text of the question being asked, e.g. "Please rank these search results from best to worst"
             id (string): The UUID of this question, if it has been created. Otherwise, it will be None.
             options (list of strings): Required. A list of the options being ranked.
+            options_info (list of objects): Additional information about the options if the question has already been created. Otherwise, it will be None.
             preexisting_annotations (string): You can use preexisting annotations to prepopulate the named entity tagger.
                 This must contain serialized data in the same format outputted by the ranking tool.
             allow_ranking_ties (boolean): Optional. Whether or not to allow ties in the ranking. If ties are allowed, two options can be ranked in the same group.
             column_header (string): This value will be used as the column header for the results table on the Surge AI site and in results CSV and JSON files.
+            hidden_by_option_id (string): If set, this question will be visible by default but hidden when the option with the provided id is selected.
+            shown_by_option_id (string). If set, this question will be hidden by default but shown when the option with the provided id is selected.
         '''
         super().__init__(id, text, type_="ranking", required=required, column_header=column_header)
         self.options = options
+        self.options_info = options_info
         self.allow_ranking_ties = allow_ranking_ties
+        self.hidden_by_option_id = hidden_by_option_id
+        self.shown_by_option_id = shown_by_option_id
 
 
 class ChatBot(Question):
@@ -311,11 +411,14 @@ class ChatBot(Question):
             text,
             id=None,
             options=[],
+            options_info=None,
             endpoint_url=None,
             endpoint_headers=None,
             preexisting_annotations=None,
             required=False,
-            column_header=None):
+            column_header=None,
+            hidden_by_option_id=None,
+            shown_by_option_id=None):
         '''
         Create an interactive chatbot on the labeling page. This is an advanced item type.
 
@@ -323,17 +426,30 @@ class ChatBot(Question):
             text (string): This text will appear above the chatbot and can be used to specify any instructions.
             id (string): The UUID of this question, if it has been created. Otherwise, it will be None.
             options (list of strings): Options for rating chatbot responses.
+            options_info (list of objects): Additional information about the options if the question has already been created. Otherwise, it will be None.
             endpoint_url (string): A URL to send chat responses to. It must include a "text" field in its response.
             endpoint_headers (string): Please provide a JSON string with any headers that need to be set when calling this URL.
             column_header (string): This value will be used as the column header for the results table on the Surge AI site and in results CSV and JSON files.
+            hidden_by_option_id (string): If set, this question will be visible by default but hidden when the option with the provided id is selected.
+            shown_by_option_id (string). If set, this question will be hidden by default but shown when the option with the provided id is selected.
         '''
         super().__init__(id, text, type_="chat", required=required, column_header=column_header)
         self.options = options
+        self.options_info = options_info
         self.endpoint_url = endpoint_url
         self.endpoint_headers = endpoint_headers
         self.preexisting_annotations=preexisting_annotations
+        self.hidden_by_option_id = hidden_by_option_id
+        self.shown_by_option_id = shown_by_option_id
 
 
 class TextArea(Question):
-    def __init__(self, text, id=None):
+    def __init__(
+            self,
+            text,
+            id=None,
+            hidden_by_option_id=None,
+            shown_by_option_id=None):
         super().__init__(id, text, type_="text", required=False)
+        self.hidden_by_option_id = hidden_by_option_id
+        self.shown_by_option_id = shown_by_option_id

--- a/surge/reports.py
+++ b/surge/reports.py
@@ -7,6 +7,7 @@ from surge.api_resource import REPORTS_ENDPOINT, APIResource
 
 
 class Report(APIResource):
+
     def __init__(self, **kwargs):
         super().__init__()
         self.__dict__.update(kwargs)
@@ -21,7 +22,11 @@ class Report(APIResource):
         return self.print_attrs(forbid_list=["id"])
 
     @classmethod
-    def save_report(cls, project_id: str, type: str, filepath=None, poll_time=30):
+    def save_report(cls,
+                    project_id: str,
+                    type: str,
+                    filepath=None,
+                    poll_time=30):
         '''
         Request creation of a report, poll until the report is generated, and save the data to a file all in one call.
         Args:
@@ -40,13 +45,14 @@ class Report(APIResource):
             # Download zipped project results if ready
             if response.status == "READY":
                 file_ext = "csv" if "csv" in type else "json"
-                default_file_name = "project_{project_id}_results.{file_ext}.gzip".format(project_id=project_id, file_ext=file_ext)
+                default_file_name = "project_{project_id}_results.{file_ext}.gzip".format(
+                    project_id=project_id, file_ext=file_ext)
                 downloaded_file, http_message = urllib.request.urlretrieve(
-                    response.url, default_file_name
-                )
+                    response.url, default_file_name)
                 # Unzip and save results
-                data =  gzip.open(downloaded_file, "r").read()
-                open(filepath or default_file_name.rstrip('.gzip'), "wb").write(data)
+                data = gzip.open(downloaded_file, "r").read()
+                open(filepath or default_file_name.rstrip('.gzip'),
+                     "wb").write(data)
                 return None
 
             # Wait two seconds before polling again
@@ -54,9 +60,13 @@ class Report(APIResource):
                 sleep(2)
                 continue
             else:
-                raise ValueError("Report failed to generate with status {}".format(response.status))
+                raise ValueError(
+                    "Report failed to generate with status {}".format(
+                        response.status))
 
-            raise Exception("Report failed to generate within {poll_time} seconds".format(poll_time=poll_time))
+            raise Exception(
+                "Report failed to generate within {poll_time} seconds".format(
+                    poll_time=poll_time))
 
     @classmethod
     def request(cls, project_id: str, type: str):

--- a/surge/responses.py
+++ b/surge/responses.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 
 class Response(object):
+
     def __init__(self, id: str):
         self.id = id
 
@@ -20,6 +21,7 @@ class Response(object):
 
 
 class TaskResponse(Response):
+
     def __init__(self, id: str, data: dict, completed_at: datetime,
                  worker_id: str):
         super().__init__(id)

--- a/surge/tasks.py
+++ b/surge/tasks.py
@@ -6,6 +6,7 @@ from surge.responses import TaskResponse
 
 
 class Task(APIResource):
+
     def __init__(self, **kwargs):
         super().__init__()
         self.__dict__.update(kwargs)

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -302,6 +302,7 @@ def test_convert_questions_to_objects():
         'options': [],
         'endpoint_url': "https://google.com",
         'endpoint_headers': None,
+        'preexisting_annotations': None,
     }]
 
     project = Project(id="ABC1234", name="Hello World")

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -114,7 +114,9 @@ def test_init_complete():
                 'created_at': '2021-01-22T19:53:04.560Z',
                 'updated_at': '2021-01-22T19:53:04.560Z',
                 'order': 3
-            }]
+            }],
+            'hidden_by_item_option_id': None,
+            'shown_by_item_option_id': None,
         }]
     }
 
@@ -201,7 +203,9 @@ def test_convert_questions_to_objects():
             'created_at': '2021-02-20T20:56:34.543Z',
             'updated_at': '2021-02-20T20:56:34.543Z',
             'order': 2
-        }]
+        }],
+        'hidden_by_item_option_id': None,
+        'shown_by_item_option_id': None,
     }, {
         'id':
         'c4b0d6a9-f735-40c1-9b42-0414945ef2db',
@@ -234,7 +238,9 @@ def test_convert_questions_to_objects():
             'created_at': '2021-02-20T20:56:34.551Z',
             'updated_at': '2021-02-20T20:56:34.551Z',
             'order': 2
-        }]
+        }],
+        'hidden_by_item_option_id': None,
+        'shown_by_item_option_id': None,
     }, {
         'id': '6123463e-349e-4450-80d2-6684a28755b3',
         'text': 'Free response for {{url}}',
@@ -244,7 +250,9 @@ def test_convert_questions_to_objects():
         'preexisting_annotations': None,
         'type': 'free_response',
         'options': [],
-        'options_objects': []
+        'options_objects': [],
+        'hidden_by_item_option_id': None,
+        'shown_by_item_option_id': None,
     }, {
         'id':
         'c46e2714-9bf6-44a8-aac3-f01f9fec8ae2',
@@ -286,14 +294,18 @@ def test_convert_questions_to_objects():
             'created_at': '2021-02-20T20:56:34.575Z',
             'updated_at': '2021-02-20T20:56:34.575Z',
             'order': 3
-        }]
+        }],
+        'hidden_by_item_option_id': None,
+        'shown_by_item_option_id': None,
     }, {
         'id': '6123463e-349e-4450-80d2-6684a28755b4',
         'text': 'Text area for {{url}}',
         'type': 'text',
         'required': False,
         'options': [],
-        'options_objects': []
+        'options_objects': [],
+        'hidden_by_item_option_id': None,
+        'shown_by_item_option_id': None,
     }, {
         'id': '6123463e-349e-4450-80d2-6684a28755b5',
         'text': 'Chatbot for {{url}}',
@@ -303,6 +315,8 @@ def test_convert_questions_to_objects():
         'endpoint_url': "https://google.com",
         'endpoint_headers': None,
         'preexisting_annotations': None,
+        'hidden_by_item_option_id': None,
+        'shown_by_item_option_id': None,
     }]
 
     project = Project(id="ABC1234", name="Hello World")


### PR DESCRIPTION
A few changes were necessary to allow for show/hide by option via the SDK:
1. Add new fields to questions (`id`, `hidden_by_option_id`, `shown_by_option_id` and `options_info`. Last one has the item option ids.)
2. Make `Question` inherit from `ApiResource` and add an update method to it

Tested this on local and seems to work. would like to add unit tests, need to familiarize myself a little more with pytest

This will probably be easiest to review commit by commit, especially since the last one is completely irrelevant but is just linting.