### PR TITLE
Make report download use tempfile

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '1.1.2'
+VERSION = '1.1.3'
 
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()


### PR DESCRIPTION
This PR makes it so that the `Report.save_report` code uses `tempfile` and `shutil` when downloading the file so that the downloaded file is created via tempfile. That means in environments where the CWD (current working directory, directory script is run in) is not writeable, we can still download files as `tempfile` should use `/tmp`.

More on tempfile here: https://docs.python.org/3/library/tempfile.html

Questions:

- do we need to add `tempfile` and `shutil` to the requirements.txt? seems to work fine locally w/o that but not sure
- is `tempfile` `python3` only? if so, is that okay?

This is to solve the problem that ZipRecruiter ran into:

> Ashley Chang
>   [4:03 PM](https://surge-ai.slack.com/archives/C05KS786R6W/p1690930991690789)
> Hey 
> [@Cymen Vig](https://surge-ai.slack.com/team/U01LCSQCN77)
> , I  confirmed that we access project this way but just remembered the reason we couldn’t use Report.save_report() when setting this up last year. Report.save_report()  takes a local path to download the report to, but in practice what it does is download it first to the local directory where the script is called, then tries to move the results to the local path provided. This was (and still is) an issue for us b/c we can only write to /tmp  or otherwise specified volumes in our containers.
> Calling Project.retrieve()  and then using request.urlretrieve() allowed us to get around this issue…so we’re back at square 1 now.