### PR TITLE
add ability to set base_url via surge.base_url

### DIFF
--- a/surge/__init__.py
+++ b/surge/__init__.py
@@ -6,3 +6,4 @@ from surge.teams import Team
 from surge.reports import Report
 
 api_key = os.environ.get("SURGE_API_KEY", None)
+base_url = os.environ.get("SURGE_BASE_URL", "https://app.surgehq.ai/api")

--- a/surge/api_resource.py
+++ b/surge/api_resource.py
@@ -3,8 +3,6 @@ import requests
 import surge
 from surge.errors import SurgeRequestError, SurgeMissingAPIKeyError
 
-BASE_URL = "https://app.surgehq.ai/api"
-
 PROJECTS_ENDPOINT = "projects"
 TASKS_ENDPOINT = "tasks"
 REPORTS_ENDPOINT = "projects"
@@ -29,7 +27,7 @@ class APIResource(object):
             raise SurgeMissingAPIKeyError
 
         try:
-            url = f"{BASE_URL}/{api_endpoint}"
+            url = f"{surge.base_url}/{api_endpoint}"
 
             # GET request
             if method == "get":


### PR DESCRIPTION
I was trying to compare localhost to production for something and I realized there wasn't an easy way to pass in the `base_url`. So I added it with the same pattern as `api_key`.

I didn't update the docs or anything as I think this is only of interest to us internally.