### PR TITLE
Use query params instead of data for get requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '1.4.0'
+VERSION = '1.5.0'
 
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()

--- a/surge/api_resource.py
+++ b/surge/api_resource.py
@@ -34,7 +34,7 @@ class APIResource(object):
             if method == "get":
                 response = requests.get(url,
                                         auth=(api_key_to_use, ""),
-                                        data=params)
+                                        params=params)
 
             # POST request
             elif method == "post":

--- a/tests/test_api_resource.py
+++ b/tests/test_api_resource.py
@@ -27,7 +27,7 @@ def test_raise_exception_if_invalid_api_key():
 def test_passed_in_api_key(mocker):
     mock_request = mocker.patch.object(requests, 'get')
     APIResource._base_request("get", surge.api_resource.PROJECTS_ENDPOINT, api_key="passed_api_key")
-    mock_request.assert_called_once_with("https://app.surgehq.ai/api/projects", auth=("passed_api_key", ""), data=None)
+    mock_request.assert_called_once_with("https://app.surgehq.ai/api/projects", auth=("passed_api_key", ""), params=None)
 
 def test_print_attrs():
     a1 = APIResource(id="ABC1234").print_attrs()


### PR DESCRIPTION
not very common to send data in a request body for a get request. let's assume we're using query params instead