### PR TITLE
Fix status options on Project APIs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '1.5.6'
+VERSION = '1.5.7'
 
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()

--- a/surge/projects.py
+++ b/surge/projects.py
@@ -1,3 +1,4 @@
+from typing import List
 import dateutil.parser
 import datetime
 import json
@@ -138,7 +139,7 @@ class Project(APIResource):
         return cls(**response_json)
 
     @classmethod
-    def list(cls, page: int = 1, statuses: list[str] = [], api_key: str = None):
+    def list(cls, page: int = 1, statuses: List[str] = None, api_key: str = None):
         '''
         Lists all projects you have created.
         Projects are returned in descending order of created_at.
@@ -150,13 +151,15 @@ class Project(APIResource):
         Returns:
             projects (list): list of Project objects.
         '''
-        params = {"page": page, "statuses": statuses}
+        params = {"page": page}
+        if statuses:
+            params["statuses[]"] = statuses
         response_json = cls.get(PROJECTS_ENDPOINT, params, api_key=api_key)
         projects = [cls(**project_json) for project_json in response_json]
         return projects
 
     @classmethod
-    def list_shared(cls, page: int = 1, statuses: list[str] = [], api_key: str = None):
+    def list_shared(cls, page: int = 1, statuses: List[str] = None, api_key: str = None):
         '''
         Lists all projects created by anyone in your organization.
         Projects are returned in descending order of created_at.
@@ -168,7 +171,9 @@ class Project(APIResource):
         Returns:
             projects (list): list of Project objects.
         '''
-        params = {"page": page, "statuses": statuses}
+        params = {"page": page}
+        if statuses:
+            params["statuses[]"] = statuses
         endpoint = f"{PROJECTS_ENDPOINT}/shared"
         response_json = cls.get(endpoint, params, api_key=api_key)
         projects = [cls(**project_json) for project_json in response_json]


### PR DESCRIPTION
Fixes #83

- Use typing library for type hints. 
- Fixes `statuses` option - this wasn't working previously. Now we send values as `statuses[]` instead of `statuses`. 
- Increment library version

Tested with: 

```
from surge import *
api_key = ...
projects = Project.list(api_key=api_key, statuses=['unlaunched'])
```

Confirmed: 
- No import errors on Python 3.11
- `projects` is filtered properly