### PR TITLE
Downgrade CI to Python 3.9 since it is the last supported Python version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
     docker:
       # Specify the version you desire here
       # See:https://circleci.com/developer/images/image/cimg/python
-      - image: cimg/python:3.8
+      - image: cimg/python:3.9
 
     # Add steps to the job
     # See: https://circleci.com/docs/jobs-steps/#steps-overview & https://circleci.com/docs/configuration-reference/#steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
     docker:
       # Specify the version you desire here
       # See:https://circleci.com/developer/images/image/cimg/python
-      - image: cimg/python:3.6
+      - image: cimg/python:3.8
 
     # Add steps to the job
     # See: https://circleci.com/docs/jobs-steps/#steps-overview & https://circleci.com/docs/configuration-reference/#steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
     docker:
       # Specify the version you desire here
       # See:https://circleci.com/developer/images/image/cimg/python
-      - image: cimg/python:3.13
+      - image: cimg/python:3.6
 
     # Add steps to the job
     # See: https://circleci.com/docs/jobs-steps/#steps-overview & https://circleci.com/docs/configuration-reference/#steps

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     license="MIT",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     packages=find_packages(exclude=["tests", "tests.*"]),
     install_requires=requirements,
     tests_require=["pytest >= 6.0.0"],

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     license="MIT",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     packages=find_packages(exclude=["tests", "tests.*"]),
     install_requires=requirements,
     tests_require=["pytest >= 6.0.0"],


### PR DESCRIPTION
This will ensure that we don't accidentally use unsupported features. 3.9 is the oldest supported Python version right now https://devguide.python.org/versions/