### PR TITLE
Mark private_workforce as deprecated

### DIFF
--- a/examples/Surge SDK Example.ipynb
+++ b/examples/Surge SDK Example.ipynb
@@ -28,7 +28,6 @@
     "project = surge.Project.create(\n",
     "    name=\"Categorize this website\",\n",
     "    payment_per_response=0.0,\n",
-    "    private_workforce=True,\n",
     "    num_workers_per_task=3,\n",
     "    fields_template='{{company}}',\n",
     "    instructions=\"You will be asked to categorize a company.\",\n",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = "1.5.11"
+VERSION = "1.5.12"
 
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()

--- a/surge/projects.py
+++ b/surge/projects.py
@@ -76,7 +76,7 @@ class Project(APIResource):
         cls,
         name: str,
         payment_per_response: float = None,
-        private_workforce: bool = False,
+        private_workforce: bool = False, # Deprecated.
         instructions: str = None,
         questions: list = [],
         qualifications_required: list = [],
@@ -99,8 +99,7 @@ class Project(APIResource):
             name (str): Name of the project.
             payment_per_response (float, optional):
                 How much a worker is paid (in US dollars) for an individual response.
-            private_workforce (bool, optional):
-                Indicates if the project's tasks will be done by a private workforce.
+            private_workforce (bool, optional): Deprecated
             instructions (str, optional): Instructions shown to workers describing how they should complete the task.
             questions (list, optional): An array of question objects describing the questions to be answered.
             qualifications_required (list, optional): Deprecated in favor of teams_required.
@@ -128,7 +127,7 @@ class Project(APIResource):
 
         params = {
             "name": name,
-            "private_workforce": private_workforce,
+            "private_workforce": False,
             "instructions": instructions,
             "questions": questions_json,
             "qualifications_required": teams_required,

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -53,7 +53,6 @@ def test_init_complete():
         "link_to_work_on_task": "https://app.surgehq.ai/workers/tasks?project_id=A1B2C3-abcd-1234-wxyz-5823gd2238ac",
         "avg_gold_standard_score": 65.09,
         "interrater_agreement": {"What is this video?": 0.859154078549849},
-        "private_workforce": False,
         "num_tasks_in_progress": 0,
         "payment_per_response": 0.12,
         "questions": [


### PR DESCRIPTION
Someone from Bard was asking about this field because they saw it in our github (it is no longer in our documentation). I don't think we want to allow private workforce projects on our platform anymore, so marking the field as deprecated + stopping the field from actually being passed through.