### PR TITLE
Enable updating chat_advanced_options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dmypy.json
 # VS Code
 .vscode
 .idea
+
+# local notebooks
+local_notebooks/

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = "1.5.14"
+VERSION = "1.5.15"
 
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()

--- a/surge/api_resource.py
+++ b/surge/api_resource.py
@@ -40,7 +40,7 @@ class APIResource(object):
             elif method == "post":
                 if files is not None:
                     response = requests.post(
-                        url, auth=(api_key_to_use, ""), files=files, data=params
+                        url, auth=(api_key_to_use, ""), files=files, json=params
                     )
                 else:
                     response = requests.post(
@@ -50,7 +50,7 @@ class APIResource(object):
             # PUT request
             elif method == "put":
                 if params is not None and len(params):
-                    response = requests.put(url, auth=(api_key_to_use, ""), data=params)
+                    response = requests.put(url, auth=(api_key_to_use, ""), json=params)
                 else:
                     response = requests.put(url, auth=(api_key_to_use, ""))
 

--- a/surge/questions.py
+++ b/surge/questions.py
@@ -39,7 +39,6 @@ class Question(APIResource):
 
     @classmethod
     def from_params(cls, q):
-        print("Q: ", q)
         options_info = q["options_objects"] if "options_objects" in q else None
         if options_info:
             for info in options_info:

--- a/surge/questions.py
+++ b/surge/questions.py
@@ -39,6 +39,7 @@ class Question(APIResource):
 
     @classmethod
     def from_params(cls, q):
+        print("Q: ", q)
         options_info = q["options_objects"] if "options_objects" in q else None
         if options_info:
             for info in options_info:
@@ -185,12 +186,15 @@ class Question(APIResource):
                 hidden_by_option_id=q["hidden_by_item_option_id"],
                 holistic=q["holistic"],
                 question_category=q.get("question_category"),
-                carousel_round=q.get("carousel_round"))
+                carousel_round=q.get("carousel_round"),
+                chat_advanced_options=q.get("chat_advanced_options")
+                )
 
     def update(self,
                text: str = None,
                hidden_by_option_id: str = None,
                shown_by_option_id: str = None,
+               chat_advanced_options: any = None,
                api_key: str = None):
         params = {}
 
@@ -200,9 +204,13 @@ class Question(APIResource):
             params["hidden_by_item_option_id"] = hidden_by_option_id
         if shown_by_option_id is not None:
             params["shown_by_item_option_id"] = shown_by_option_id
+        if chat_advanced_options is not None:
+            params["chat_advanced_options"] = chat_advanced_options
 
         endpoint = f"{QUESTIONS_ENDPOINT}/{self.id}"
+        print("Params: ", params)
         response_json = self.put(endpoint, params, api_key=api_key)
+        print("Response: ", response_json)
         return Question.from_params(response_json)
 
 
@@ -651,7 +659,8 @@ class ChatBot(Question):
                  shown_by_option_id=None,
                  holistic=False,
                  question_category=None,
-                 carousel_round=None):
+                 carousel_round=None,
+                 chat_advanced_options=None):
         '''
         Create an interactive chatbot on the labeling page. This is an advanced item type.
 
@@ -684,7 +693,7 @@ class ChatBot(Question):
         self.hidden_by_option_id = hidden_by_option_id
         self.shown_by_option_id = shown_by_option_id
         self.holistic = holistic
-
+        self.chat_advanced_options = chat_advanced_options
 
 class TextArea(Question):
 

--- a/surge/questions.py
+++ b/surge/questions.py
@@ -208,9 +208,7 @@ class Question(APIResource):
             params["chat_advanced_options"] = chat_advanced_options
 
         endpoint = f"{QUESTIONS_ENDPOINT}/{self.id}"
-        print("Params: ", params)
         response_json = self.put(endpoint, params, api_key=api_key)
-        print("Response: ", response_json)
         return Question.from_params(response_json)
 
 

--- a/tests/test_api_resource.py
+++ b/tests/test_api_resource.py
@@ -53,7 +53,7 @@ def test_passed_in_file():
             "https://app.surgehq.ai/api/projects",
             auth=("passed_api_key", ""),
             files=files,
-            data=None,
+            json=None,
         )
 
 


### PR DESCRIPTION
Summary:

Support chat advanced options in the questions sdk.

test plan:
manually confirm that setting chat advanced options works and updates the db and ui.