### PR TITLE
Raise error when fetching report for empty project

### DIFF
--- a/surge/reports.py
+++ b/surge/reports.py
@@ -157,6 +157,8 @@ class Report(APIResource):
         endpoint = f"{REPORTS_ENDPOINT}/{project_id}/report"
         params = {"report_type": type}
         response_json = cls.post(endpoint, params, api_key=api_key)
+        if "error" in response_json:
+            raise SurgeRequestError(response_json["error"])
         return cls(**response_json)
 
     @classmethod

--- a/surge/reports.py
+++ b/surge/reports.py
@@ -7,7 +7,7 @@ import io
 import json
 
 from surge.api_resource import REPORTS_ENDPOINT, APIResource
-
+from surge.errors import SurgeRequestError
 
 class Report(APIResource):
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,10 @@
+from surge import Report
+from surge.errors import SurgeRequestError
+from unittest import mock
+import pytest
+
+def test_save_report_on_empty_project_raises_an_error():
+    with mock.patch.object(Report, "post") as mock_post:
+        mock_post.return_value = { "error": "Project has no responses" }
+        with pytest.raises(SurgeRequestError):
+            Report.save_report("fake_project_id", "export_csv", "my_report.csv")


### PR DESCRIPTION
The error message sent by the server when attempting to download the report of a project without responses is currently being ignored. This raises an error instead. 