### PR TITLE
Allow Project.save_report to load the report directly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ python-dateutil==2.9.0.post0
 requests==2.32.3
 six==1.17.0
 urllib3==2.4.0
+pandas>=2.0.0

--- a/surge/api_resource.py
+++ b/surge/api_resource.py
@@ -1,4 +1,6 @@
 import requests
+import io
+import pandas as pd
 
 import surge
 from surge.errors import SurgeRequestError, SurgeMissingAPIKeyError
@@ -119,3 +121,17 @@ class APIResource(object):
     def delete_request(cls, api_endpoint, api_key=None):
         method = "delete"
         return cls._base_request(method, api_endpoint, api_key=api_key)
+
+    @classmethod
+    def _format(self, output: str, data: str):
+        if output is None:
+            return
+        if output == "raw":
+            return data
+        stringIO = io.StringIO(data)
+        if output == "stringio":
+            return stringIO
+        if output == "dataframe":
+            return pd.read_csv(stringIO)
+        else:
+            raise ValueError("`output` can only be one of: `raw`, `stringio` or `dataframe`")

--- a/surge/projects.py
+++ b/surge/projects.py
@@ -412,6 +412,7 @@ class Project(APIResource):
         filepath=None,
         poll_time=5 * 60,
         api_key: str = None,
+        output: str = "dataframe"
     ):
         """
         Request creation of a report, poll until the report is generated, and save the data to a file all in one call.
@@ -431,6 +432,7 @@ class Project(APIResource):
             filepath=filepath,
             poll_time=poll_time,
             api_key=api_key,
+            output=output
         )
 
     def download_json(self, poll_time=5 * 60, api_key: str = None):

--- a/surge/reports.py
+++ b/surge/reports.py
@@ -7,6 +7,7 @@ import io
 import json
 
 from surge.api_resource import REPORTS_ENDPOINT, APIResource
+from surge.errors import SurgeRequestError
 
 
 class Report(APIResource):
@@ -32,6 +33,7 @@ class Report(APIResource):
         filepath=None,
         poll_time=5 * 60,
         api_key: str = None,
+        output: str = "dataframe"
     ):
         """
         Request creation of a report, poll until the report is generated, and save the data to a file all in one call.
@@ -73,7 +75,7 @@ class Report(APIResource):
                         file.write(data)
                         if isinstance(filepath, str):
                             file.close()
-                return
+                return cls._format(output, data.decode("utf-8"))
 
             # Wait two seconds before polling again
             elif response.status == "CREATING":


### PR DESCRIPTION
This is a quality-of-life improvement allowing the `Project.save_report` method to load the contents of the report directly, instead of requiring the user to load the downloaded file themselves. The report is loaded as a `pandas.DataFrame` by default, but it can also be outputted as a `StringIO` or raw string.