### PR TITLE
Rename Report.status to Report.check_status to avoid name shadowing

### DIFF
--- a/surge/reports.py
+++ b/surge/reports.py
@@ -5,6 +5,7 @@ import tempfile
 import shutil
 import io
 import json
+import warnings
 
 from surge.api_resource import REPORTS_ENDPOINT, APIResource
 
@@ -158,6 +159,49 @@ class Report(APIResource):
         params = {"report_type": type}
         response_json = cls.post(endpoint, params, api_key=api_key)
         return cls(**response_json)
+    
+    @classmethod
+    def status(cls, project_id: str, job_id: str, api_key: str = None):
+        """
+        Deprecated (use `check_status` instead). Checks the status of a given report job. The response will be of one of these shapes:
+
+        1) Report is still being generated (HTTP 202):
+
+          {
+            status: "IN_PROGRESS",
+          }
+
+        2) Report is completed:
+
+          {
+            status: "COMPLETED",
+            url: ...,
+            expires_in_seconds: ...,
+          }
+
+        3) Retrying generation of report (can consider this to be same as in progress):
+
+          {
+            status: "RETRYING",
+            job_id: ...,
+          }
+
+        4) Error (HTTP 400 or 500):
+
+          {
+            status: "ERROR",
+            type: ...
+          }
+
+        Arguments:
+          project_id (str): ID of project.
+          job_id (str): ID of the report job
+
+        Returns:
+            status: Report status object
+        """
+        warnings.warn("Use check_status instead", DeprecationWarning)
+        return cls.check_status(project_id, job_id, api_key=api_key)
 
     @classmethod
     def check_status(cls, project_id: str, job_id: str, api_key: str = None):


### PR DESCRIPTION
In the current code, `Report.status` refers to two things:
- A class method to check the status of a report
- The status attribute of a `Report` object

The problem is that instances of the class also have class methods, which introduces confusion, as accessing `status` on an instance will refer to:
- the attribute if it has been set by the API response
- the class method otherwise
When accessing `status` on an instance, VS Code's static code analysis identifies it as the class method.

This renames the class method to avoid confusion.