### PR TITLE
Forward params on DELETE requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = "1.5.22"
+VERSION = "1.5.23"
 
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()

--- a/surge/api_resource.py
+++ b/surge/api_resource.py
@@ -143,8 +143,6 @@ class APIResource(object):
 
     @classmethod
     def delete_request(cls, api_endpoint, api_key=None, params=None):
-        # api_key precedes params to preserve positional backward
-        # compatibility with callers that predate the params argument.
         method = "delete"
         return cls._base_request(method,
                                  api_endpoint,

--- a/surge/api_resource.py
+++ b/surge/api_resource.py
@@ -77,6 +77,7 @@ class APIResource(object):
             elif method == "delete":
                 response = requests.delete(url,
                                            auth=(api_key_to_use, ""),
+                                           params=params,
                                            **header_kwargs)
 
             elif method == "patch":
@@ -141,6 +142,9 @@ class APIResource(object):
                                  api_key=api_key)
 
     @classmethod
-    def delete_request(cls, api_endpoint, api_key=None):
+    def delete_request(cls, api_endpoint, params=None, api_key=None):
         method = "delete"
-        return cls._base_request(method, api_endpoint, api_key=api_key)
+        return cls._base_request(method,
+                                 api_endpoint,
+                                 params=params,
+                                 api_key=api_key)

--- a/surge/api_resource.py
+++ b/surge/api_resource.py
@@ -142,7 +142,9 @@ class APIResource(object):
                                  api_key=api_key)
 
     @classmethod
-    def delete_request(cls, api_endpoint, params=None, api_key=None):
+    def delete_request(cls, api_endpoint, api_key=None, params=None):
+        # api_key precedes params to preserve positional backward
+        # compatibility with callers that predate the params argument.
         method = "delete"
         return cls._base_request(method,
                                  api_endpoint,

--- a/tests/test_api_resource.py
+++ b/tests/test_api_resource.py
@@ -71,3 +71,19 @@ def test_get_passed_in_file():
 def test_print_attrs():
     a1 = APIResource(id="ABC1234").print_attrs()
     assert a1 == 'id="ABC1234"'
+
+
+def test_delete_request_forwards_params():
+    with mock.patch.object(requests, "delete") as mock_request:
+        mock_request.return_value = mock.MagicMock()
+        APIResource._base_request(
+            "delete",
+            surge.api_resource.PROJECTS_ENDPOINT,
+            params={"foo": "bar"},
+            api_key="passed_api_key",
+        )
+        mock_request.assert_called_once_with(
+            "https://app.surgehq.ai/api/projects",
+            auth=("passed_api_key", ""),
+            params={"foo": "bar"},
+        )


### PR DESCRIPTION
`delete_request` was the only HTTP helper that didn't take a `params` argument, forcing callers to hand-encode query strings into the endpoint when they needed to attach filters or scoping params to a DELETE.

Adds `params=None` to `delete_request` and threads it through `_base_request` to `requests.delete(..., params=...)`, matching `get`/`post`/`put`/`patch`.

Bumps version to 1.5.23.